### PR TITLE
fix: change Props theme type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export type Props = {
-  theme: object;
+  theme: object | any;
 };
 
 export type Orientation = 'portrait' | 'landscape';


### PR DESCRIPTION
I'm having an issue in my project, in which I'm using custom, typed Emotion styled instance. Made with:
https://github.com/emotion-js/emotion/blob/52530f05dfff0e2d93c940336faa70a9c6696006/packages/styled/types/index.d.ts#L174

With that configuration I'm receiving following ts error whenever I use styled-breakpoints in styled component:

```TS2339: Property 'foo' does not exist on type 'object'.```

![issue](https://user-images.githubusercontent.com/35396312/81320108-f2b72280-9090-11ea-9dbb-34ee00aa4ae1.png)

Setting theme type same as in CreateStyled resolves that issue