### PR TITLE
fix: rewrite useBreakpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,9 +275,11 @@ only('md') => '@media (min-width: 768px) and (max-width: 991.98px) { ... }'
 /**
  * @param {function} up | down | between | only
  *
- * @return {boolean} is the target breakpoint
+ * @return {(boolean|null)} `true` if currently matching the given query,
+ *                          `false` if not, and `null` if unknown (such as
+ *                          during server-side rendering)
  */
-useBreakpoint(up('md')) => boolean
+useBreakpoint(up('md')) => boolean | null
 ```
 
 ## Other

--- a/react-emotion/index.d.ts
+++ b/react-emotion/index.d.ts
@@ -1,1 +1,1 @@
-export declare function useBreakpoint(breakpoint: Function): boolean;
+export declare function useBreakpoint(breakpoint: Function): boolean | null;

--- a/react-emotion/index.js
+++ b/react-emotion/index.js
@@ -1,24 +1,41 @@
-const { useState, useEffect } = require('react');
+const { useState, useEffect, useCallback } = require('react');
 const { useTheme } = require('@emotion/react');
 
 const useBreakpoint = (breakpoint) => {
+  // Get the media query to match
   const query = breakpoint({
     theme: useTheme(),
-  }).replace(/^@media/, '');
+  }).replace(/^@media\s*/, '');
 
-  const mq = window.matchMedia(query);
-  const [isBreak, setIsBreak] = useState(mq.matches);
+  // Keep track of current media query match state;
+  // initialize this to the current match state if possible,
+  // or to null (to mean "indeterminate" if the `window` object isn't available)
+  const [isBreak, setIsBreak] = useState(
+    typeof window !== 'undefined' ? window.matchMedia(query).matches : null
+  );
 
+  // Handler for the media query change event
+  const handleChange = useCallback((event) => {
+    setIsBreak(event.matches);
+  }, []);
+
+  // Set up a media query matcher on mount and if the query changes
   useEffect(() => {
-    const handleResize = () => {
-      setIsBreak(window.matchMedia(query).matches);
+    const mq = window.matchMedia(query);
+
+    // Ensure the correct value is set in state as soon as possible
+    setIsBreak(mq.matches);
+
+    // Update the state whenever the media query match state changes
+    mq.addEventListener('change', handleChange);
+
+    // Clean up on unmount and if the query changes
+    return function cleanup() {
+      mq.removeEventListener('change', handleChange);
     };
+  }, [query, handleChange]);
 
-    window.addEventListener('resize', handleResize);
-
-    return () => window.removeEventListener('resize', handleResize);
-  }, [query]);
-
+  // Return the current match state
   return isBreak;
 };
 

--- a/react-styled/index.d.ts
+++ b/react-styled/index.d.ts
@@ -1,1 +1,1 @@
-export declare function useBreakpoint(breakpoint: Function): boolean;
+export declare function useBreakpoint(breakpoint: Function): boolean | null;


### PR DESCRIPTION
This changeset rewrites useBreakpoint and fixes #860.

The hook now returns either a boolean or `null`; `null` in the case where `window` doesn't exist and so whether or not the query matches is unknown. It now no longer sets a `resize` handler on `window`, instead using the `change` event of the media query list. This is much more efficient.

I honestly don't know *exactly* what in the old version was causing the bug, but it's definitely fixed with this new version!

Note that I have never used Emotion, and have not tested the emotion version here. But given that the old version of the React one was identical to the old version of the Emotion one other than one of the require lines at the top, I expect it to be fine.