### PR TITLE
fix: useBreakpoint: don't attempt to initialize state

### DIFF
--- a/react-emotion/index.js
+++ b/react-emotion/index.js
@@ -8,11 +8,8 @@ const useBreakpoint = (breakpoint) => {
   }).replace(/^@media\s*/, '');
 
   // Keep track of current media query match state;
-  // initialize this to the current match state if possible,
-  // or to null (to mean "indeterminate" if the `window` object isn't available)
-  const [isBreak, setIsBreak] = useState(
-    typeof window !== 'undefined' ? window.matchMedia(query).matches : null
-  );
+  // null means "indeterminate", eg if the `window` object isn't available
+  const [isBreak, setIsBreak] = useState(null);
 
   // Handler for the media query change event
   const handleChange = useCallback((event) => {

--- a/react-styled/index.js
+++ b/react-styled/index.js
@@ -8,11 +8,8 @@ const useBreakpoint = (breakpoint) => {
   }).replace(/^@media\s*/, '');
 
   // Keep track of current media query match state;
-  // initialize this to the current match state if possible,
-  // or to null (to mean "indeterminate" if the `window` object isn't available)
-  const [isBreak, setIsBreak] = useState(
-    typeof window !== 'undefined' ? window.matchMedia(query).matches : null
-  );
+  // null means "indeterminate", eg if the `window` object isn't available
+  const [isBreak, setIsBreak] = useState(null);
 
   // Handler for the media query change event
   const handleChange = useCallback((event) => {


### PR DESCRIPTION
I'm not entirely sure why, but initializing the hook state was still leading to the bug seen in #860, though only when refreshing at a narrow width.

When initializing to null in all cases I no longer see the broken case.

Apologies for not testing thoroughly enough yesterday! Initializing the state to the media query match state immediately if `window` was available, outside of `useEffect`, was something of an afterthought; I didn't have it in my test case implementation. Should have tested more thoroughly after adding that.

I wish I knew exactly what the problem is here. I wonder if it's a bug in styled-components or Next or even React...