### PR TITLE
add exception for MediaQueryList event listener for Safari < 14

### DIFF
--- a/react-styled/index.js
+++ b/react-styled/index.js
@@ -22,6 +22,18 @@ const useBreakpoint = (breakpoint) => {
     // Ensure the correct value is set in state as soon as possible
     setIsBreak(mq.matches);
 
+    // Safari < 14 can't use addEventListener on a MediaQueryList
+    // https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#Browser_compatibility
+    if (!mq.addEventListener) {
+      // Update the state whenever the media query match state changes
+      mq.addListener(handleChange);
+
+      // Clean up on unmount and if the query changes
+      return function cleanup() {
+        mq.removeListener(handleChange);
+      };
+    }
+
     // Update the state whenever the media query match state changes
     mq.addEventListener('change', handleChange);
 


### PR DESCRIPTION
Hey! 
Thanks for the styled-components integration. 
Found a bug in old Safari today when we launched our new site. 
Apparently Safari < 14 can't use [addEventListener on a MediaQueryList](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#Browser_compatibility), so this adds a check to see which api to use. 

I used patch-package to get around it for now, but let me know if there is anything I can adjust for you here! 

Thanks!