### PR TITLE
refactor: rewrite function `down` and `between` and add function `createTheme`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -136,6 +136,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "bdefore",
+      "name": "Buck DeFore",
+      "avatar_url": "https://avatars.githubusercontent.com/u/142472?v=4",
+      "profile": "https://github.com/bdefore",
+      "contributions": [
+        "ideas"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -145,6 +145,15 @@
       "contributions": [
         "ideas"
       ]
+    },
+    {
+      "login": "pierreburel",
+      "name": "Pierre Burel",
+      "avatar_url": "https://avatars.githubusercontent.com/u/37228?v=4",
+      "profile": "https://www.pierreburel.com/",
+      "contributions": [
+        "bug"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -139,16 +139,14 @@ const Component = styled.div`
 ### Customization
 
 ```jsx
-import { up, down, between, only } from 'styled-breakpoints';
+import { up, down, between, only, createTheme } from 'styled-breakpoints';
 
-const theme = {
-  breakpoints: {
-    sm: '576px',
-    md: '768px',
-    lg: '992px',
-    xl: '1200px',
-  },
-};
+const theme = createTheme({
+  sm: '576px',
+  md: '768px',
+  lg: '992px',
+  xl: '1200px',
+});
 
 const Component = styled.div`
   color: black;

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ css`
 <details><summary><strong>Convert to: </strong></summary>
 
 ```css
-@media (max-width: 991.98px) {
+@media (max-width: 767.98px) {
   background-color: rebeccapurple;
 }
 ```
@@ -307,7 +307,7 @@ Similarly, media queries may span multiple breakpoint widths:
 
 ```js
 css`
-  ${between('md', 'lg')} {
+  ${between('md', 'xl')} {
     background-color: rebeccapurple;
   }
 `;

--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/all-contri
     <td align="center"><a href="https://bartnagel.ca/"><img src="https://avatars1.githubusercontent.com/u/199635?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Bart Nagel</b></sub></a><br /><a href="https://github.com/mg901/styled-breakpoints/issues?q=author%3Atremby" title="Bug reports">🐛</a> <a href="https://github.com/mg901/styled-breakpoints/commits?author=tremby" title="Code">💻</a> <a href="#example-tremby" title="Examples">💡</a> <a href="#ideas-tremby" title="Ideas, Planning, & Feedback">🤔</a></td>
     <td align="center"><a href="https://mckelveygreg.github.io/"><img src="https://avatars2.githubusercontent.com/u/16110122?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Greg McKelvey</b></sub></a><br /><a href="https://github.com/mg901/styled-breakpoints/commits?author=mckelveygreg" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/bdefore"><img src="https://avatars.githubusercontent.com/u/142472?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Buck DeFore</b></sub></a><br /><a href="#ideas-bdefore" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://www.pierreburel.com/"><img src="https://avatars.githubusercontent.com/u/37228?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Pierre Burel</b></sub></a><br /><a href="https://github.com/mg901/styled-breakpoints/issues?q=author%3Apierreburel" title="Bug reports">🐛</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/all-contri
     <td align="center"><a href="https://iryanbell.com/"><img src="https://avatars0.githubusercontent.com/u/25379378?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ryan Bell</b></sub></a><br /><a href="#ideas-iRyanBell" title="Ideas, Planning, & Feedback">🤔</a></td>
     <td align="center"><a href="https://bartnagel.ca/"><img src="https://avatars1.githubusercontent.com/u/199635?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Bart Nagel</b></sub></a><br /><a href="https://github.com/mg901/styled-breakpoints/issues?q=author%3Atremby" title="Bug reports">🐛</a> <a href="https://github.com/mg901/styled-breakpoints/commits?author=tremby" title="Code">💻</a> <a href="#example-tremby" title="Examples">💡</a> <a href="#ideas-tremby" title="Ideas, Planning, & Feedback">🤔</a></td>
     <td align="center"><a href="https://mckelveygreg.github.io/"><img src="https://avatars2.githubusercontent.com/u/16110122?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Greg McKelvey</b></sub></a><br /><a href="https://github.com/mg901/styled-breakpoints/commits?author=mckelveygreg" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/bdefore"><img src="https://avatars.githubusercontent.com/u/142472?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Buck DeFore</b></sub></a><br /><a href="#ideas-bdefore" title="Ideas, Planning, & Feedback">🤔</a></td>
   </tr>
 </table>
 

--- a/core/breakpoints.js
+++ b/core/breakpoints.js
@@ -41,12 +41,12 @@ exports.createBreakpoints = memoize(
       return names[nextIndex];
     };
 
-    const getNextValueByName = (name) => {
+    const getNextValueByName = memoize((name) => {
       validation.checkIsValidName(name);
       validation.checkIsLastName(name);
 
       return breakpoints[getNextName(name)];
-    };
+    });
 
     // Maximum breakpoint width. Null for the largest (last) breakpoint.
     // The maximum value is calculated as the minimum of the next one less 0.02px
@@ -54,22 +54,24 @@ exports.createBreakpoints = memoize(
     // See https://www.w3.org/TR/mediaqueries-4/#mq-min-max
     // Uses 0.02px rather than 0.01px to work around a current rounding bug in Safari.
     // See https://bugs.webkit.org/show_bug.cgi?id=178261
-    const calcMaxWidth = memoize((name) => {
-      const nextValue = getNextValueByName(name);
-
-      return `${parseFloat(nextValue) - 0.02}px`;
-    });
-
-    const between = (min, max) => ({
-      min: getValueByName(min),
-      max: calcMaxWidth(max),
+    const calcMaxWidth = memoize((value) => {
+      return `${parseFloat(value) - 0.02}px`;
     });
 
     return {
       up: getValueByName,
-      down: calcMaxWidth,
-      between,
-      only: (name) => between(name, name),
+
+      down: (max) => calcMaxWidth(getValueByName(max)),
+
+      between: (min, max) => ({
+        min: getValueByName(min),
+        max: calcMaxWidth(getValueByName(max)),
+      }),
+
+      only: (name) => ({
+        min: getValueByName(name),
+        max: calcMaxWidth(getNextValueByName(name)),
+      }),
     };
   }
 );

--- a/core/breakpoints.spec.js
+++ b/core/breakpoints.spec.js
@@ -1,6 +1,6 @@
 const { createBreakpoints, ERROR_PREFIX } = require('./breakpoints');
 
-const { up, down, between, only, DEFAULT_BREAKPOINTS } = createBreakpoints();
+const { up, down, between, only } = createBreakpoints();
 
 describe('core/create-breakpoints', () => {
   describe('up', () => {
@@ -25,7 +25,15 @@ describe('core/create-breakpoints', () => {
     });
 
     it('should render correctly breakpoints by default', () => {
-      new Map(DEFAULT_BREAKPOINTS).forEach((value, key) => {
+      const results = [
+        ['sm', '576px'],
+        ['md', '768px'],
+        ['lg', '992px'],
+        ['xl', '1200px'],
+        ['xxl', '1400px'],
+      ];
+
+      results.forEach(([key, value]) => {
         expect(up(key)).toEqual(value);
       });
     });
@@ -44,10 +52,11 @@ describe('core/create-breakpoints', () => {
 
     it('should render correctly breakpoints by default', () => {
       const results = [
-        ['sm', '767.98px'],
-        ['md', '991.98px'],
-        ['lg', '1199.98px'],
-        ['xl', '1399.98px'],
+        ['sm', '575.98px'],
+        ['md', '767.98px'],
+        ['lg', '991.98px'],
+        ['xl', '1199.98px'],
+        ['xxl', '1399.98px'],
       ];
 
       results.forEach(([key, value]) => {
@@ -88,9 +97,9 @@ describe('core/create-breakpoints', () => {
     });
 
     it('return an object with the minimum and maximum screen width', () => {
-      expect(between('sm', 'md')).toEqual({
-        min: '576px',
-        max: '991.98px',
+      expect(between('md', 'xl')).toEqual({
+        max: '1199.98px',
+        min: '768px',
       });
     });
 
@@ -117,9 +126,9 @@ describe('core/create-breakpoints', () => {
     });
 
     it('return an object with the minimum and maximum screen width', () => {
-      expect(only('sm')).toEqual({
-        max: '767.98px',
-        min: '576px',
+      expect(only('md')).toEqual({
+        max: '991.98px',
+        min: '768px',
       });
     });
 

--- a/styled-breakpoints/index.d.ts
+++ b/styled-breakpoints/index.d.ts
@@ -15,3 +15,9 @@ export declare function createStyledBreakpoints(
   between: (min: string, max: string, orientation?: Orientation) => any;
   only: (name: string, orientation?: Orientation) => any;
 };
+
+export declare function createTheme<T extends Record<string, string>>(
+  breakpoints: T
+): {
+  ['styled-breakpoints']: T;
+};

--- a/styled-breakpoints/index.js
+++ b/styled-breakpoints/index.js
@@ -1,3 +1,14 @@
-const { createStyledBreakpoints } = require('./styled-breakpoints');
+const {
+  createStyledBreakpoints,
+  createTheme,
+} = require('./styled-breakpoints');
 
-exports.createStyledBreakpoints = createStyledBreakpoints;
+const { up, down, between, only } = createStyledBreakpoints();
+
+module.exports = {
+  up,
+  down,
+  between,
+  only,
+  createTheme,
+};

--- a/styled-breakpoints/styled-breakpoints.js
+++ b/styled-breakpoints/styled-breakpoints.js
@@ -3,7 +3,7 @@ const { createBreakpoints } = require('../core');
 
 const defaultOptions = {
   errorPrefix: '[styled-breakpoints]: ',
-  pathToMediaQueries: 'breakpoints',
+  pathToMediaQueries: 'styled-breakpoints.breakpoints',
   defaultBreakpoints: {
     xs: '0px',
     sm: '576px',
@@ -105,3 +105,9 @@ exports.createStyledBreakpoints = (options = defaultOptions) => {
       ),
   };
 };
+
+exports.createTheme = (breakpoints) => ({
+  'styled-breakpoints': {
+    breakpoints,
+  },
+});

--- a/styled-breakpoints/styled-breakpoints.spec.js
+++ b/styled-breakpoints/styled-breakpoints.spec.js
@@ -1,4 +1,7 @@
-const { createStyledBreakpoints } = require('./styled-breakpoints');
+const {
+  createStyledBreakpoints,
+  createTheme,
+} = require('./styled-breakpoints');
 
 const ERROR_PREFIX = '[styled-breakpoints]: ';
 const PROPS_WITH_EMPTY_THEME = {
@@ -39,9 +42,7 @@ describe('styled-breakpoints', () => {
     };
 
     const props = {
-      theme: {
-        breakpoints,
-      },
+      theme: createTheme(breakpoints),
     };
 
     Object.entries(breakpoints).forEach(([key, value]) => {
@@ -82,20 +83,20 @@ describe('styled-breakpoints', () => {
 
   describe('down', () => {
     it('should render a media query if the screen width is less or equal to 575.98px', () => {
-      expect(down('xs')(PROPS_WITH_EMPTY_THEME)).toEqual(
+      expect(down('sm')(PROPS_WITH_EMPTY_THEME)).toEqual(
         '@media (max-width: 575.98px)'
       );
     });
 
     it('should render a media query if the screen width is less or equal to 767.98px for portrait orientation', () => {
       expect(down('sm', 'portrait')(PROPS_WITH_EMPTY_THEME)).toEqual(
-        '@media (max-width: 767.98px) and (orientation: portrait)'
+        '@media (max-width: 575.98px) and (orientation: portrait)'
       );
     });
 
     it('should render a media query if the screen width is less or equal to 767.98px for landscape orientation', () => {
       expect(down('sm', 'landscape')(PROPS_WITH_EMPTY_THEME)).toEqual(
-        '@media (max-width: 767.98px) and (orientation: landscape)'
+        '@media (max-width: 575.98px) and (orientation: landscape)'
       );
     });
 
@@ -113,19 +114,19 @@ describe('styled-breakpoints', () => {
   describe('between', () => {
     it('should render a media query if the screen width greater than equal to 576px and less than or equal to 991.98px', () => {
       expect(between('sm', 'md')(PROPS_WITH_EMPTY_THEME)).toEqual(
-        '@media (min-width: 576px) and (max-width: 991.98px)'
+        '@media (min-width: 576px) and (max-width: 767.98px)'
       );
     });
 
     it('should render a media query if the screen width greater than equal to 576px and less than or equal to 991.98px and portrait orientation', () => {
       expect(between('sm', 'md', 'portrait')(PROPS_WITH_EMPTY_THEME)).toEqual(
-        '@media (min-width: 576px) and (max-width: 991.98px) and (orientation: portrait)'
+        '@media (min-width: 576px) and (max-width: 767.98px) and (orientation: portrait)'
       );
     });
 
     it('should render a media query if the screen width greater than equal to 576px and less than or equal to 991.98px and landscape orientation', () => {
       expect(between('sm', 'md', 'landscape')(PROPS_WITH_EMPTY_THEME)).toEqual(
-        '@media (min-width: 576px) and (max-width: 991.98px) and (orientation: landscape)'
+        '@media (min-width: 576px) and (max-width: 767.98px) and (orientation: landscape)'
       );
     });
   });


### PR DESCRIPTION
BREAKING CHANGE: add createTheme function to resolve name conflicts when [merging multiple themes](https://github.com/mg901/styled-breakpoints/issues/1138) with custom breakpoints.

```diff
+ import { createTheme } from 'styled-breakpoints';

- const theme = {
-  breakpoints: {
-    sm: '576px',
-    md: '768px',
-    lg: '992px',
-    xl: '1200px',
-  },
-};

+ const theme = createTheme({
+  sm: '600px',
+  md: '900px',
+  lg: '1200px'
+})

<ThemeProvider theme={theme}>
  <Component>This is cool!</Component>
</ThemeProvider>;
```

Completely rewritten algorithm for calculating breakpoints for `down` and `between` functions to [align with Bootstrap 5](https://github.com/mg901/styled-breakpoints/issues/1119).

```diff
- down('md') => @media (max-width: 991.98px)
+ down('md') => @media (max-width: 767.98px) 
```

```diff
- between('md', 'lg') => @media (min-width: 768px) and (max-width: 1199.98px)
+ between('md', 'lg') => @media (min-width: 768px) and (max-width: 991.98px)
```