### PR TITLE
chore: bump react from v17.0.1 to v18.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.0.0",
-    "react": "^17.x.x",
+    "react": "^18.x.x",
     "styled-components": "^5.0.0"
   },
   "peerDependenciesMeta": {
@@ -156,7 +156,7 @@
     "jest": "^28.0.0",
     "lint-staged": "^12.3.8",
     "prettier": "^2.1.2",
-    "react": "^17.0.1",
+    "react": "^18.1.0",
     "rimraf": "^3.0.2",
     "size-limit": "^7.0.8",
     "styled-components": "^5.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6760,13 +6760,12 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.0.0.tgz#026f6c4a27dbe33bf4a35655b9e1327c4e55e3f5"
   integrity sha512-yUcBYdBBbo3QiPsgYDcfQcIkGZHfxOaoE6HLSnr1sPzMhdyxusbfKOSUbSd/ocGi32dxcj366PsTj+5oggeKKw==
 
-react@^17.0.1:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@^18.1.0:
+  version "18.1.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.1.0.tgz#6f8620382decb17fdc5cc223a115e2adbf104890"
+  integrity sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
BREAKING CHANGE: No breaking changes