### PR TITLE
fix: createTheme method has wrong types

### DIFF
--- a/styled-breakpoints/index.d.ts
+++ b/styled-breakpoints/index.d.ts
@@ -19,5 +19,5 @@ export declare function createStyledBreakpoints(
 export declare function createTheme<T extends Record<string, string>>(
   breakpoints: T
 ): {
-  ['styled-breakpoints']: T;
+  ['styled-breakpoints']: { breakpoints: T };
 };


### PR DESCRIPTION
Hey, I found this bug while working with your lib. The createTheme method didn't have `breakpoints` object spread, but types were stating it did.