### PR TITLE
fix: optimize 'only' method for O(1) performance

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -3,19 +3,19 @@ module.exports = [
     name: 'breakpoints',
     path: './breakpoints/create-breakpoints-api.prod.js',
     import: '{ createBreakpointsApi }',
-    limit: '254 B',
+    limit: '295 B',
   },
   {
     name: 'breakpoints.dev',
     path: './breakpoints/create-breakpoints-api.dev.js',
     import: '{ createBreakpointsApi }',
-    limit: '804 B',
+    limit: '840 B',
   },
   {
     name: 'styled-breakpoints',
     path: './styled-breakpoints/create-styled-breakpoints-theme/index.js',
     import: '{ createStyledBreakpointsTheme }',
-    limit: '725 B',
+    limit: '770 B',
   },
   {
     name: 'styled-breakpoints + useMediaQuery',
@@ -29,6 +29,6 @@ module.exports = [
       './styled-breakpoints/index.js': '{ createStyledBreakpointsTheme }',
       './use-media-query/index.js': '{ useMediaQuery }',
     },
-    limit: '985 B',
+    limit: '1.1 kB',
   },
 ];

--- a/breakpoints/create-breakpoints-api.prod.js
+++ b/breakpoints/create-breakpoints-api.prod.js
@@ -1,12 +1,23 @@
 const { calcMaxWidth } = require('./calc-max-width');
 
-exports.createBreakpointsApi = ({ breakpoints }) => {
-  const keys = Object.keys(Object(breakpoints));
+exports.createBreakpointsApi = ({ breakpoints = {} }) => {
+  const indexMap = {};
+  const keys = Object.keys(breakpoints);
 
-  const getNextKey = (key) => keys[keys.indexOf(key) + 1];
+  keys.forEach((key, index) => {
+    indexMap[key] = index;
+  });
 
   const up = (min) => breakpoints[min];
   const down = (max) => calcMaxWidth(breakpoints[max]);
+
+  const getNextKey = (key) => {
+    const currentIndex = indexMap[key];
+    const nextIndex = currentIndex + 1;
+    const isNotLastIndex = currentIndex < keys.length - 1;
+
+    return isNotLastIndex ? keys[nextIndex] : undefined;
+  };
 
   const between = (min, max) => ({
     min: up(min),
@@ -14,7 +25,7 @@ exports.createBreakpointsApi = ({ breakpoints }) => {
   });
 
   const only = (key) =>
-    key === keys.at(-1) ? up(key) : between(key, getNextKey(key));
+    key !== keys.at(-1) ? between(key, getNextKey(key)) : up(key);
 
   return {
     keys,


### PR DESCRIPTION
This commit improves the performance of the 'only' method by optimizing it to achieve constant time complexity (O(1)). Previously, it had a time complexity of O(n). This significant performance enhancement will lead to faster and more efficient 'only' method execution.